### PR TITLE
ALC 292 Configuration Fix (Verified on Lenovo T440s)

### DIFF
--- a/CodecCommander/CodecCommander-Info.plist
+++ b/CodecCommander/CodecCommander-Info.plist
@@ -199,7 +199,19 @@
 							<key>Comment</key>
 							<string>Node 0x1a - Pin Control (In Enable / VRefEn)</string>
 							<key>On Init</key>
+							<true/>
+							<key>On Sleep</key>
 							<false/>
+							<key>On Wake</key>
+							<true/>
+						</dict>
+						<dict>
+							<key>Command</key>
+							<data>AVcIgw==</data>
+							<key>Comment</key>
+							<string>0x15 SET_UNSOLICITED_ENABLE 0x83</string>
+							<key>On Init</key>
+							<true/>
 							<key>On Sleep</key>
 							<false/>
 							<key>On Wake</key>


### PR DESCRIPTION
Fixed ALC 292 headphone jack detection along with headphone jack static.  I no longer need to use this kext in conjunction with EAPDFix.kext (just CodecCommander is enough).  This fix works after wake from sleep too.